### PR TITLE
SSR support

### DIFF
--- a/examples/kitchen-sink/nuxt.config.js
+++ b/examples/kitchen-sink/nuxt.config.js
@@ -16,6 +16,7 @@ module.exports = {
     description: 'Nuxt7 PWA Demo'
   },
   framework7: {
+    ssr: true,
     themeColor: '#2196f3',
     mode: 'history',
     foo: 'bar',

--- a/lib/module.js
+++ b/lib/module.js
@@ -14,15 +14,19 @@ module.exports = function nuxt7 (_options) {
   }
 
   // Force mode to SPA
-  this.options.mode = 'spa'
-  this.options.render.ssr = false
-  this.options.build.ssr = false
+  if (!options.ssr) {
+    this.options.mode = 'spa'
+    this.options.render.ssr = false
+    this.options.build.ssr = false
+  }
 
   // Disable postcss for less transformations
   this.options.build.postcss = false
 
   // Customize build
-  this.extendBuild(config => extendConfig(config, options))
+  this.extendBuild((config, { isServer }) =>
+    extendConfig(config, options, isServer)
+  )
 
   // Global theme color
   if (options.themeColor) {
@@ -36,6 +40,7 @@ module.exports = function nuxt7 (_options) {
   }
 
   // Move F7 dependencies to common chunk
+  this.addVendor(`framework7`)
   this.addVendor(`framework7-vue`)
   this.addVendor('dom7')
   this.addVendor('template7')
@@ -144,29 +149,47 @@ function addTemplates (options) {
 // ----------------------------------------------------------
 // Extend webpack config
 // ----------------------------------------------------------
-function extendConfig (config, options) {
+function extendConfig (config, options, isServer) {
   // Increase performance check limits to 2M (non-gzipped)
   const MAX_SIZE = 2 * 1024 * 1024
   Object.assign(config.performance, {
     maxEntrypointSize: MAX_SIZE,
     maxAssetSize: MAX_SIZE
   })
+
+  if (isServer) {
+    config.resolve.alias['__framework7__'] = 'framework7/dist/js/framework7'
+  } else {
+    config.resolve.alias['__framework7__'] =
+      'framework7/dist/framework7.esm.bundle'
+  }
 }
 
 // ----------------------------------------------------------
 // Default options
 // ----------------------------------------------------------
 const extraKeys = [
-  'build', 'mode', 'themeColor', 'css', 'f7Icons', 'mdIcons', 'f7IconsSrc', 'mdIconsSrc', 'pwa', 'routes'
+  'build',
+  'mode',
+  'themeColor',
+  'css',
+  'f7Icons',
+  'mdIcons',
+  'f7IconsSrc',
+  'mdIconsSrc',
+  'pwa',
+  'routes',
+  'ssr'
 ]
 
 const defaults = {
   build: Object.assign({}, f7BuildConfig),
 
-  mode: 'hash',
+  mode: 'history',
   css: true,
   f7Icons: true,
   mdIcons: true,
+  ssr: false,
 
   routes: {},
 

--- a/lib/templates/f7-plugin.js
+++ b/lib/templates/f7-plugin.js
@@ -5,7 +5,7 @@ import { routes } from './f7-router'
 import Framework7VueComponents from './f7-components'
 
 // Async import F7 core
-const _Framework7 = import('framework7/dist/framework7.esm.bundle' /* webpackChunkName: "f7" */).then(m => m.default)
+const _Framework7 = import('__framework7__' /* webpackChunkName: "f7" */).then(m => m.default)
 
 // Register F7 Vue Components
 Vue.use(Framework7VueComponents)


### PR DESCRIPTION
- Added a new `ssr` option (Defaults to `false`)
- Add an alias for SSR bundle to use non-ESM build (Should f7 use `.mjs` for ESM files?)
- Change default router mode to `history`

Pending:
- Framework7 (Specially utils) needs including `ssr-window`