### PR TITLE
Add support for latest Framework7 v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ to rapidly create efficient and feature-reach [PWA](https://developers.google.co
 
 ## ✨ Features
 
-* Fully compatible with framework7 2.x
+* Fully compatible with Framework7 5.x
 * Development mode with hot reloading
 * Optimized production builds suitable for 100% static hosting
 * Fully PWA compatible out of the box

--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ Enable RTL Layout.
 
 Enable darkTheme support.
 
+### `lightTheme`
+
+- Type: `boolean`
+- Default: `true`
+
+Enable lightTheme support.
+
 ### `colors`
 
 - Type: `object`

--- a/examples/kitchen-sink/layouts/default.vue
+++ b/examples/kitchen-sink/layouts/default.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <f7-statusbar></f7-statusbar>
     <f7-panel left cover>
       <f7-view url="/panel-left/" links-view=".view-main"></f7-view>
     </f7-panel>

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -1,7 +1,6 @@
 // Source: https://github.com/framework7io/framework7/blob/master/scripts/build-config.js
 
 const config = {
-  target: 'universal',
   rtl: false,
   components: [
     // Appbar
@@ -108,16 +107,20 @@ const config = {
     // Tree View
     'treeview',
 
-    // VI Video Ads
-    'vi',
+    // WYSIWYG Editor
+    'text-editor',
 
     // Elevation
     'elevation',
 
     // Typography
-    'typography'
+    'typography',
+
+    // VI Video Ads
+    'vi'
   ],
   darkTheme: true,
+  lightTheme: true,
   themes: [
     'ios',
     'md',

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -18,6 +18,7 @@ module.exports = {
 
   themeColor,
   themes,
+  lightTheme: true,
   darkTheme: true,
   colors,
 

--- a/lib/module.js
+++ b/lib/module.js
@@ -29,7 +29,7 @@ function prepareBuild (_options) {
 
   // Transpile framework7
   this.options.build.transpile.push(
-    /framework7[\\/](?!less)/,
+    /framework7[\\/](?!less)(?!components\/swiper\/swiper-src\/less)/,
     'framework7-vue',
     'template7',
     'dom7'

--- a/lib/templates/framework7/styles.less
+++ b/lib/templates/framework7/styles.less
@@ -1,9 +1,11 @@
 @import (reference) '~framework7/less/mixins.less';
+@import (reference) '~framework7/less/vars.less';
 
 @includeIosTheme: <%= options.themes.indexOf('ios') >= 0 %>;
 @includeMdTheme: <%= options.themes.indexOf('md') >= 0 %>;
 @includeAuroraTheme: <%= options.themes.indexOf('aurora') >= 0 %>;
 
+@includeLightTheme: <%= options.lightTheme %>;
 @includeDarkTheme: <%= options.darkTheme %>;
 
 @themeColor: <%= options.themeColor %>;

--- a/lib/templates/layouts/default.vue
+++ b/lib/templates/layouts/default.vue
@@ -1,10 +1,8 @@
 <script>
-import { f7Statusbar } from 'framework7-vue'
 
 export default {
   render (h) {
     return h('div',[
-      h(f7Statusbar),
       h('nuxt')
     ])
   },

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "defu": "^0.0.1",
-    "framework7": "^4.4.0",
-    "framework7-vue": "^4.4.0",
+    "framework7": "^5.7.0",
+    "framework7-vue": "^5.7.0",
     "less": "^3.9.0",
     "less-loader": "^5.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4086,20 +4086,20 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framework7-vue@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/framework7-vue/-/framework7-vue-4.4.0.tgz#56b02b553666eb0141238da620b5747c74c705a9"
-  integrity sha512-LMuplgsGWRHKdlwcuqD07R2FZxe09ExTxUTLJ1p91vy3tm8zL+dTMhFYDmRQd0UwvnoDlQQsqscyDKnJR7wHGA==
+framework7-vue@^5.7.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/framework7-vue/-/framework7-vue-5.7.1.tgz#5ab940e5c9a8fc5567707b87d649735a15cc2a96"
+  integrity sha512-2gAncfli6asgm7+KqIHyoOyx2GRAa6Oplrx8Ul/y9TQMUMkaI4sCPhcJQaWiyJ7iM1rvvy5kHMfgZFmlqxNC8g==
 
-framework7@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/framework7/-/framework7-4.4.0.tgz#141a3686f58c0905760c3a2243a19fa44a6a4b90"
-  integrity sha512-x23Kmux2HuhFiYINUoTOlw0YjDapSdj1xmlwcgz8kTu1ZgnCXIqxv1UyOUrvHPosoKQmaIY8WgfL3uXCZYWvFA==
+framework7@^5.7.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/framework7/-/framework7-5.7.1.tgz#048e34c5b5f72b94bd2e4ba2e62f394ed003720a"
+  integrity sha512-o45wa7lx6sW4GEYZORRUfx/yJq1crj2niPXjvn9XNjicZUymeHm9OE0NSaShKvLWpZ90U+joAbMHceZH0+PUJw==
   dependencies:
     dom7 "^2.1.3"
-    path-to-regexp "^3.0.0"
+    path-to-regexp "^6.1.0"
     ssr-window "^1.0.1"
-    template7 "^1.4.1"
+    template7 "^1.4.2"
 
 fresh@0.5.2, fresh@^0.5.2:
   version "0.5.2"
@@ -6385,10 +6385,10 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
-path-to-regexp@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-3.0.0.tgz#c981a218f3df543fa28696be2f88e0c58d2e012a"
-  integrity sha512-ZOtfhPttCrqp2M1PBBH4X13XlvnfhIwD7yCLx+GoGoXRPQyxGOTdQMpIzPSPKXAJT/JQrdfFrgdJOyAzvgpQ9A==
+path-to-regexp@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.1.0.tgz#0b18f88b7a0ce0bfae6a25990c909ab86f512427"
+  integrity sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -8434,10 +8434,10 @@ tarr@1.0.3:
     fstream "^1.0.2"
     inherits "2"
 
-template7@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/template7/-/template7-1.4.1.tgz#c3b2b03d6879e1c5f8a79067c961c8896ffaeec6"
-  integrity sha512-sYZ9Wl5kFuNSvLcMPq8z4oenG7rDho6KnB2vWyvMJCdI1guJhxTEU0TCwr6Nd1Jx34kSOmrpJakMGxJgCc55yg==
+template7@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/template7/-/template7-1.4.2.tgz#62f32959361e455ec171ef9ef33d29ca7130e009"
+  integrity sha512-eoKnScBMDk7lyj7+iCzKbxGiSLLlQk0DNvmclyJuMCUKxy9JrFuAB+GD5iplF4WiQPtMdI06CHHks3avL22JXA==
 
 term-size@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Hi @pi0 🖖

More and more people are interested in using of Nuxt with Framework7 (lots of request of Framework7 forum), so this small PR adds support for latest Framework7 v5, by:

* adding new components and props to custom build
* tweak to babel transpile to bypass Swiper's less compilation
* remove obsolete components like `Statusbar`
* update F7 dependencies to latest

As i see it is still not possible to make it work correctly in SSR mode, but this is one of my next goals for v6  